### PR TITLE
BLE: fix serial TX flow control regression (Remote Control 30 s hang)

### DIFF
--- a/applications/services/bt/bt_cli.c
+++ b/applications/services/bt/bt_cli.c
@@ -7,8 +7,10 @@
 
 #include <ble/ble.h>
 #include "bt_service/bt.h"
+#include "bt_service/bt_i.h"
 #include "bt_service/bt_settings_api_i.h"
 #include <profiles/serial_profile.h>
+#include <services/serial_service.h>
 
 static void bt_cli_command_hci_info(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(pipe);
@@ -132,6 +134,54 @@ static void bt_cli_command_packet_tx(PipeSide* pipe, FuriString* args, void* con
     } while(false);
 }
 
+static void bt_cli_command_serial_stats(PipeSide* pipe, FuriString* args, void* context) {
+    UNUSED(pipe);
+    UNUSED(context);
+
+    Bt* bt = furi_record_open(RECORD_BT);
+
+    do {
+        if(!bt->current_profile ||
+           !furi_hal_bt_check_profile_type(bt->current_profile, ble_profile_serial)) {
+            printf("Serial profile not active\r\n");
+            break;
+        }
+
+        FuriString* sub = furi_string_alloc();
+        bool do_reset = args_read_string_and_trim(args, sub) &&
+                        furi_string_cmp_str(sub, "reset") == 0;
+        furi_string_free(sub);
+
+        if(do_reset) {
+            ble_profile_serial_reset_stats(bt->current_profile);
+            printf("Serial stats reset\r\n");
+            break;
+        }
+
+        BleServiceSerialStats stats;
+        ble_profile_serial_get_stats(bt->current_profile, &stats);
+
+        /* tx_submitted counts fragments; a healthy link has tx_acked catching
+         * up closely behind. Sustained (tx_submitted - tx_acked) growth, a
+         * non-zero tx_errors, or heavy tx_retries indicate a wedged stack
+         * or peer that stopped ACKing. rx_overruns means the peer is
+         * ignoring the FFF4 credit characteristic. */
+        printf("BLE serial stats:\r\n");
+        printf("  TX submitted : %lu\r\n", (unsigned long)stats.tx_submitted);
+        printf("  TX acked     : %lu\r\n", (unsigned long)stats.tx_acked);
+        printf(
+            "  TX in flight : %ld\r\n",
+            (long)((int64_t)stats.tx_submitted - (int64_t)stats.tx_acked));
+        printf("  TX retries   : %lu\r\n", (unsigned long)stats.tx_retries);
+        printf("  TX errors    : %lu\r\n", (unsigned long)stats.tx_errors);
+        printf("  RX bytes     : %lu\r\n", (unsigned long)stats.rx_bytes);
+        printf("  RX overruns  : %lu\r\n", (unsigned long)stats.rx_overruns);
+        printf("  Credit resets: %lu\r\n", (unsigned long)stats.credits_resets);
+    } while(false);
+
+    furi_record_close(RECORD_BT);
+}
+
 static void bt_cli_command_packet_rx(PipeSide* pipe, FuriString* args, void* context) {
     UNUSED(context);
     int channel = 0;
@@ -172,6 +222,7 @@ static void bt_cli_print_usage(void) {
     printf("bt <cmd> <args>\r\n");
     printf("Cmd list:\r\n");
     printf("\thci_info\t - HCI info\r\n");
+    printf("\tserial_stats [reset]\t - BLE serial flow-control diagnostics\r\n");
     if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug) && furi_hal_bt_is_testing_supported()) {
         printf("\ttx_carrier <channel:0-39> <power:0-6>\t - start tx carrier test\r\n");
         printf("\trx_carrier <channel:0-39>\t - start rx carrier test\r\n");
@@ -197,6 +248,10 @@ static void execute(PipeSide* pipe, FuriString* args, void* context) {
         }
         if(furi_string_cmp_str(cmd, "hci_info") == 0) {
             bt_cli_command_hci_info(pipe, args, NULL);
+            break;
+        }
+        if(furi_string_cmp_str(cmd, "serial_stats") == 0) {
+            bt_cli_command_serial_stats(pipe, args, NULL);
             break;
         }
         if(furi_hal_rtc_is_flag_set(FuriHalRtcFlagDebug) && furi_hal_bt_is_testing_supported()) {

--- a/applications/services/bt/bt_service/bt.c
+++ b/applications/services/bt/bt_service/bt.c
@@ -15,6 +15,13 @@
 #define BT_RPC_EVENT_DISCONNECTED (1UL << 1)
 #define BT_RPC_EVENT_ALL          (BT_RPC_EVENT_BUFF_SENT | BT_RPC_EVENT_DISCONNECTED)
 
+/* Upper bound on how long we'll wait for a single BLE indication to be ACKed
+ * by the peer before abandoning the RPC message. With a healthy link the ACK
+ * arrives within one connection interval (~7.5–45 ms); 2 s is a generous
+ * ceiling that guarantees the RPC thread can never deadlock on a wedged
+ * stack. On timeout we abort the in-flight message and let the peer retry. */
+#define BT_RPC_TX_ACK_TIMEOUT_MS 2000
+
 #define ICON_SPACER 2
 
 static void bt_draw_statusbar_callback(Canvas* canvas, void* context) {
@@ -231,16 +238,31 @@ static void bt_rpc_send_bytes_callback(void* context, uint8_t* bytes, size_t byt
     size_t bytes_sent = 0;
     while(bytes_sent < bytes_len) {
         size_t bytes_remain = bytes_len - bytes_sent;
-        if(bytes_remain > bt->max_packet_size) {
-            ble_profile_serial_tx(bt->current_profile, &bytes[bytes_sent], bt->max_packet_size);
-            bytes_sent += bt->max_packet_size;
-        } else {
-            ble_profile_serial_tx(bt->current_profile, &bytes[bytes_sent], bytes_remain);
-            bytes_sent += bytes_remain;
+        size_t chunk =
+            bytes_remain > bt->max_packet_size ? bt->max_packet_size : bytes_remain;
+
+        /* Abort the whole message on a TX submission failure. Continuing would
+         * leave the RPC thread waiting FuriWaitForever for an ACK that will
+         * never arrive (the indication was never queued on the stack). */
+        if(!ble_profile_serial_tx(bt->current_profile, &bytes[bytes_sent], chunk)) {
+            FURI_LOG_E(TAG, "BLE TX submit failed, aborting RPC message");
+            break;
         }
+        bytes_sent += chunk;
+
         // We want BT_RPC_EVENT_DISCONNECTED to stick, so don't clear
         uint32_t event_flag = furi_event_flag_wait(
-            bt->rpc_event, BT_RPC_EVENT_ALL, FuriFlagWaitAny | FuriFlagNoClear, FuriWaitForever);
+            bt->rpc_event,
+            BT_RPC_EVENT_ALL,
+            FuriFlagWaitAny | FuriFlagNoClear,
+            BT_RPC_TX_ACK_TIMEOUT_MS);
+        if(event_flag == (uint32_t)FuriFlagErrorTimeout) {
+            /* Stack wedged — peer never ACKed. Abort rather than deadlock;
+             * the connection will typically be torn down by supervision
+             * timeout on the peer side, or the peer will retry. */
+            FURI_LOG_E(TAG, "BLE TX ACK timeout, aborting RPC message");
+            break;
+        }
         if(event_flag & BT_RPC_EVENT_DISCONNECTED) {
             break;
         } else {

--- a/targets/f7/api_symbols.csv
+++ b/targets/f7/api_symbols.csv
@@ -716,7 +716,9 @@ Function,-,ble_profile_hid_mouse_press,_Bool,"FuriHalBleProfileBase*, uint8_t"
 Function,-,ble_profile_hid_mouse_release,_Bool,"FuriHalBleProfileBase*, uint8_t"
 Function,-,ble_profile_hid_mouse_release_all,_Bool,FuriHalBleProfileBase*
 Function,-,ble_profile_hid_mouse_scroll,_Bool,"FuriHalBleProfileBase*, int8_t"
+Function,+,ble_profile_serial_get_stats,void,"FuriHalBleProfileBase*, BleServiceSerialStats*"
 Function,+,ble_profile_serial_notify_buffer_is_empty,void,FuriHalBleProfileBase*
+Function,+,ble_profile_serial_reset_stats,void,FuriHalBleProfileBase*
 Function,+,ble_profile_serial_set_event_callback,void,"FuriHalBleProfileBase*, uint16_t, FuriHalBtSerialCallback, void*"
 Function,+,ble_profile_serial_set_rpc_active,void,"FuriHalBleProfileBase*, _Bool"
 Function,+,ble_profile_serial_tx,_Bool,"FuriHalBleProfileBase*, uint8_t*, uint16_t"
@@ -732,7 +734,9 @@ Function,-,ble_svc_hid_stop,void,BleServiceHid*
 Function,-,ble_svc_hid_update_info,_Bool,"BleServiceHid*, uint8_t*"
 Function,-,ble_svc_hid_update_input_report,_Bool,"BleServiceHid*, uint8_t, uint8_t*, uint16_t"
 Function,-,ble_svc_hid_update_report_map,_Bool,"BleServiceHid*, const uint8_t*, uint16_t"
+Function,+,ble_svc_serial_get_stats,void,"BleServiceSerial*, BleServiceSerialStats*"
 Function,+,ble_svc_serial_notify_buffer_is_empty,void,BleServiceSerial*
+Function,+,ble_svc_serial_reset_stats,void,BleServiceSerial*
 Function,+,ble_svc_serial_set_callbacks,void,"BleServiceSerial*, uint16_t, SerialServiceEventCallback, void*"
 Function,+,ble_svc_serial_set_rpc_active,void,"BleServiceSerial*, _Bool"
 Function,+,ble_svc_serial_start,BleServiceSerial*,

--- a/targets/f7/ble_glue/profiles/serial_profile.c
+++ b/targets/f7/ble_glue/profiles/serial_profile.c
@@ -124,3 +124,17 @@ bool ble_profile_serial_tx(FuriHalBleProfileBase* profile, uint8_t* data, uint16
 
     return ble_svc_serial_update_tx(serial_profile->serial_svc, data, size);
 }
+
+void ble_profile_serial_get_stats(FuriHalBleProfileBase* profile, BleServiceSerialStats* stats) {
+    furi_check(profile && (profile->config == ble_profile_serial));
+
+    BleProfileSerial* serial_profile = (BleProfileSerial*)profile;
+    ble_svc_serial_get_stats(serial_profile->serial_svc, stats);
+}
+
+void ble_profile_serial_reset_stats(FuriHalBleProfileBase* profile) {
+    furi_check(profile && (profile->config == ble_profile_serial));
+
+    BleProfileSerial* serial_profile = (BleProfileSerial*)profile;
+    ble_svc_serial_reset_stats(serial_profile->serial_svc);
+}

--- a/targets/f7/ble_glue/profiles/serial_profile.h
+++ b/targets/f7/ble_glue/profiles/serial_profile.h
@@ -31,6 +31,19 @@ extern const FuriHalBleProfileTemplate* const ble_profile_serial;
  */
 bool ble_profile_serial_tx(FuriHalBleProfileBase* profile, uint8_t* data, uint16_t size);
 
+/** Snapshot serial-service diagnostic counters
+ *
+ * @param profile       Profile instance
+ * @param stats         Output struct populated with current counters
+ */
+void ble_profile_serial_get_stats(FuriHalBleProfileBase* profile, BleServiceSerialStats* stats);
+
+/** Zero the serial-service diagnostic counters
+ *
+ * @param profile       Profile instance
+ */
+void ble_profile_serial_reset_stats(FuriHalBleProfileBase* profile);
+
 /** Set BLE RPC status
  *
  * @param profile       Profile instance

--- a/targets/f7/ble_glue/services/serial_service.c
+++ b/targets/f7/ble_glue/services/serial_service.c
@@ -37,7 +37,7 @@ static const BleGattCharacteristicParams ble_svc_serial_chars[SerialSvcGattChara
          .data.fixed.length = BLE_SVC_SERIAL_DATA_LEN_MAX,
          .uuid.Char_UUID_128 = BLE_SVC_SERIAL_TX_CHAR_UUID,
          .uuid_type = UUID_TYPE_128,
-         .char_properties = CHAR_PROP_READ | CHAR_PROP_NOTIFY,
+         .char_properties = CHAR_PROP_READ | CHAR_PROP_INDICATE,
          .security_permissions = ATTR_PERMISSION_AUTHEN_READ,
          .gatt_evt_mask = GATT_DONT_NOTIFY_EVENTS,
          .is_variable = CHAR_VALUE_LEN_VARIABLE},
@@ -241,31 +241,45 @@ bool ble_svc_serial_update_tx(BleServiceSerial* serial_svc, uint8_t* data, uint1
     for(uint16_t remained = data_len; remained > 0;) {
         uint8_t value_len = MIN(BLE_SVC_SERIAL_CHAR_VALUE_LEN_MAX, remained);
         uint16_t value_offset = data_len - remained;
-        remained -= value_len;
+        bool is_last_fragment = (remained == value_len);
 
-        tBleStatus result = aci_gatt_update_char_value_ext(
-            conn_handle,
-            serial_svc->svc_handle,
-            serial_svc->chars[SerialSvcGattCharacteristicTx].handle,
-            remained ? 0x00 : 0x01, /* 0x01 = notification (was 0x02 = indication) */
-            data_len,
-            value_offset,
-            value_len,
-            data + value_offset);
+        /* Retry when the stack's TX pool is momentarily full. A stalled TX
+         * here used to silently fail and deadlock the RPC thread waiting
+         * for the indication ACK that would never come. Cap at ~200 ms so
+         * a persistently wedged stack surfaces as an error instead of
+         * blocking the RPC thread indefinitely. */
+        tBleStatus result = BLE_STATUS_INSUFFICIENT_RESOURCES;
+        size_t retries_left = 200;
+        while(retries_left-- > 0 && result == BLE_STATUS_INSUFFICIENT_RESOURCES) {
+            result = aci_gatt_update_char_value_ext(
+                conn_handle,
+                serial_svc->svc_handle,
+                serial_svc->chars[SerialSvcGattCharacteristicTx].handle,
+                is_last_fragment ? 0x02 : 0x00, /* 0x02 = indication (ACK-gated backpressure) */
+                data_len,
+                value_offset,
+                value_len,
+                data + value_offset);
+            if(result == BLE_STATUS_INSUFFICIENT_RESOURCES) {
+                furi_delay_ms(1);
+            }
+        }
 
-        if(result) {
+        if(result != BLE_STATUS_SUCCESS) {
             FURI_LOG_E(TAG, "Failed updating TX characteristic: %d", result);
+            /* No indication was queued, so no ACK will arrive — unblock the
+             * RPC thread so it can abort the message instead of deadlocking
+             * on BT_RPC_EVENT_BUFF_SENT. */
+            if(serial_svc->callback) {
+                SerialServiceEvent event = {
+                    .event = SerialServiceEventTypeDataSent,
+                };
+                serial_svc->callback(event, serial_svc->context);
+            }
             return false;
         }
-    }
 
-    /* Notifications are fire-and-forget — no ACK event from stack.
-     * Signal DataSent immediately so the RPC layer knows it can send more. */
-    if(serial_svc->callback) {
-        SerialServiceEvent event = {
-            .event = SerialServiceEventTypeDataSent,
-        };
-        serial_svc->callback(event, serial_svc->context);
+        remained -= value_len;
     }
 
     return true;

--- a/targets/f7/ble_glue/services/serial_service.c
+++ b/targets/f7/ble_glue/services/serial_service.c
@@ -71,7 +71,14 @@ struct BleServiceSerial {
     SerialServiceEventCallback callback;
     void* context;
     GapSvcEventHandler* event_handler;
+    BleServiceSerialStats stats;
 };
+
+/* Saturating uint32_t increment — avoids wrap-around masking real volume. */
+static inline void ble_svc_serial_stat_inc(uint32_t* counter, uint32_t delta) {
+    uint32_t current = *counter;
+    *counter = (UINT32_MAX - current < delta) ? UINT32_MAX : current + delta;
+}
 
 static BleEventAckStatus ble_svc_serial_event_handler(void* event, void* context) {
     BleServiceSerial* serial_svc = (BleServiceSerial*)context;
@@ -91,6 +98,8 @@ static BleEventAckStatus ble_svc_serial_event_handler(void* event, void* context
                 attribute_modified->Attr_Handle ==
                 serial_svc->chars[SerialSvcGattCharacteristicRx].handle + 1) {
                 FURI_LOG_D(TAG, "Received %d bytes", attribute_modified->Attr_Data_Length);
+                ble_svc_serial_stat_inc(
+                    &serial_svc->stats.rx_bytes, attribute_modified->Attr_Data_Length);
                 if(serial_svc->callback) {
                     furi_check(
                         furi_mutex_acquire(serial_svc->buff_size_mtx, FuriWaitForever) ==
@@ -101,6 +110,7 @@ static BleEventAckStatus ble_svc_serial_event_handler(void* event, void* context
                             "Received %d, while was ready to receive %d bytes. Can lead to buffer overflow!",
                             attribute_modified->Attr_Data_Length,
                             serial_svc->bytes_ready_to_receive);
+                        ble_svc_serial_stat_inc(&serial_svc->stats.rx_overruns, 1);
                     }
                     serial_svc->bytes_ready_to_receive -= MIN(
                         serial_svc->bytes_ready_to_receive, attribute_modified->Attr_Data_Length);
@@ -130,6 +140,7 @@ static BleEventAckStatus ble_svc_serial_event_handler(void* event, void* context
             }
         } else if(blecore_evt->ecode == ACI_GATT_SERVER_CONFIRMATION_VSEVT_CODE) {
             FURI_LOG_T(TAG, "Ack received");
+            ble_svc_serial_stat_inc(&serial_svc->stats.tx_acked, 1);
             if(serial_svc->callback) {
                 SerialServiceEvent event = {
                     .event = SerialServiceEventTypeDataSent,
@@ -155,6 +166,7 @@ static void
 
 BleServiceSerial* ble_svc_serial_start(void) {
     BleServiceSerial* serial_svc = malloc(sizeof(BleServiceSerial));
+    memset(&serial_svc->stats, 0, sizeof(serial_svc->stats));
 
     serial_svc->event_handler =
         ble_event_dispatcher_register_svc_handler(ble_svc_serial_event_handler, serial_svc);
@@ -201,6 +213,7 @@ void ble_svc_serial_notify_buffer_is_empty(BleServiceSerial* serial_svc) {
     if(serial_svc->bytes_ready_to_receive == 0) {
         FURI_LOG_D(TAG, "Buffer is empty. Notifying client");
         serial_svc->bytes_ready_to_receive = serial_svc->buff_size;
+        ble_svc_serial_stat_inc(&serial_svc->stats.credits_resets, 1);
 
         uint32_t buff_size_reversed = REVERSE_BYTES_U32(serial_svc->buff_size);
         ble_gatt_characteristic_update(
@@ -261,12 +274,14 @@ bool ble_svc_serial_update_tx(BleServiceSerial* serial_svc, uint8_t* data, uint1
                 value_len,
                 data + value_offset);
             if(result == BLE_STATUS_INSUFFICIENT_RESOURCES) {
+                ble_svc_serial_stat_inc(&serial_svc->stats.tx_retries, 1);
                 furi_delay_ms(1);
             }
         }
 
         if(result != BLE_STATUS_SUCCESS) {
             FURI_LOG_E(TAG, "Failed updating TX characteristic: %d", result);
+            ble_svc_serial_stat_inc(&serial_svc->stats.tx_errors, 1);
             /* No indication was queued, so no ACK will arrive — unblock the
              * RPC thread so it can abort the message instead of deadlocking
              * on BT_RPC_EVENT_BUFF_SENT. */
@@ -279,6 +294,7 @@ bool ble_svc_serial_update_tx(BleServiceSerial* serial_svc, uint8_t* data, uint1
             return false;
         }
 
+        ble_svc_serial_stat_inc(&serial_svc->stats.tx_submitted, 1);
         remained -= value_len;
     }
 
@@ -289,4 +305,18 @@ void ble_svc_serial_set_rpc_active(BleServiceSerial* serial_svc, bool active) {
     furi_check(serial_svc);
     ble_svc_serial_update_rpc_char(
         serial_svc, active ? SerialServiceRpcStatusActive : SerialServiceRpcStatusNotActive);
+}
+
+void ble_svc_serial_get_stats(BleServiceSerial* serial_svc, BleServiceSerialStats* stats) {
+    furi_check(serial_svc);
+    furi_check(stats);
+    /* Plain copy — each counter has a single writer thread and aligned
+     * 32-bit reads are atomic on Cortex-M, so no mutex needed for a
+     * best-effort diagnostic snapshot. */
+    *stats = serial_svc->stats;
+}
+
+void ble_svc_serial_reset_stats(BleServiceSerial* serial_svc) {
+    furi_check(serial_svc);
+    memset(&serial_svc->stats, 0, sizeof(serial_svc->stats));
 }

--- a/targets/f7/ble_glue/services/serial_service.h
+++ b/targets/f7/ble_glue/services/serial_service.h
@@ -34,6 +34,22 @@ typedef uint16_t (*SerialServiceEventCallback)(SerialServiceEvent event, void* c
 
 typedef struct BleServiceSerial BleServiceSerial;
 
+/** Runtime diagnostics for the serial service.
+ *
+ * All counters are monotonic, saturate at UINT32_MAX, and are cleared by
+ * ble_svc_serial_reset_stats(). Each counter has a single writer thread,
+ * so increments are race-free; a 32-bit read from another thread may be
+ * stale but not torn on Cortex-M. */
+typedef struct {
+    uint32_t tx_submitted;  /**< fragments successfully queued to the BLE stack */
+    uint32_t tx_acked;      /**< indication ACKs received (peer confirmed) */
+    uint32_t tx_retries;    /**< total INSUFFICIENT_RESOURCES retry attempts */
+    uint32_t tx_errors;     /**< TX submissions that failed after retries */
+    uint32_t rx_bytes;      /**< total bytes received on the RX characteristic */
+    uint32_t rx_overruns;   /**< peer writes that exceeded available credits */
+    uint32_t credits_resets;/**< times bytes_ready_to_receive was replenished */
+} BleServiceSerialStats;
+
 BleServiceSerial* ble_svc_serial_start(void);
 
 void ble_svc_serial_stop(BleServiceSerial* service);
@@ -49,6 +65,10 @@ void ble_svc_serial_set_rpc_active(BleServiceSerial* service, bool active);
 void ble_svc_serial_notify_buffer_is_empty(BleServiceSerial* service);
 
 bool ble_svc_serial_update_tx(BleServiceSerial* service, uint8_t* data, uint16_t data_len);
+
+void ble_svc_serial_get_stats(BleServiceSerial* service, BleServiceSerialStats* stats);
+
+void ble_svc_serial_reset_stats(BleServiceSerial* service);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

Fixes the ~30 s hang / BLE restart seen when running Remote Control from the Flipper Android app, and hardens the serial GATT path against future stack stalls.

## Root cause

Commit 138696c ("BLE: Serial TX notifications (2x throughput) + L2CAP CoC subsystem") switched the serial TX characteristic from **indications** (ACK-gated) to **notifications** (fire-and-forget) and added a synchronous `DataSent` dispatch that fired before the radio had drained. With backpressure removed, the RPC thread refilled the 1024 B stream buffer faster than the radio could empty it; after ~30 s the HCI TX pool saturated, `aci_gatt_update_char_value_ext` started silently returning `BLE_STATUS_INSUFFICIENT_RESOURCES`, and the Android app eventually wrote 0 to the RPC Status characteristic to force a profile restart.

## Phase 1 — revert the regression

`targets/f7/ble_glue/services/serial_service.c`:
- `CHAR_PROP_NOTIFY` → `CHAR_PROP_INDICATE`
- indication opcode `0x01` → `0x02`
- Removed the synchronous `SerialServiceEventTypeDataSent` dispatch. `DataSent` is once again driven only by the peer's `ACI_GATT_SERVER_CONFIRMATION`, which restores the ACK-gated backpressure the RPC thread needs.

The L2CAP CoC subsystem added in 138696c is left untouched — only the GATT serial regression was reverted.

## Phase 2 — harden against future stalls

`ble_svc_serial_update_tx`:
- Retry on `BLE_STATUS_INSUFFICIENT_RESOURCES` with ~200 ms × 1 ms backoff, mirroring the existing pattern in `furi_ble/gatt.c`.
- On final TX submission failure, synthesize a `DataSent` event so the RPC thread isn't left waiting `FuriWaitForever` for an indication ACK that will never arrive.

`applications/services/bt/bt_service/bt.c` (`bt_rpc_send_bytes_callback`):
- Honor the return value of `ble_profile_serial_tx` (previously ignored — silently advanced `bytes_sent` and waited for an ACK that never came).
- Replace `FuriWaitForever` on `BT_RPC_EVENT_BUFF_SENT` with a 2 s bounded wait. A wedged stack now surfaces as a logged timeout and aborted message instead of a permanent RPC-thread deadlock.

## Phase 3 — observability

Added monotonic 32-bit counters to `BleServiceSerial`:

| counter | bumped when |
|---|---|
| `tx_submitted` | fragment successfully queued to the stack |
| `tx_acked` | indication ACK received from peer |
| `tx_retries` | `INSUFFICIENT_RESOURCES` retry attempt |
| `tx_errors` | TX submission failed after retries exhausted |
| `rx_bytes` | bytes received on the RX characteristic |
| `rx_overruns` | peer write exceeded available credits |
| `credits_resets` | `bytes_ready_to_receive` replenished |

Counters are single-writer per thread (RX from BLE event thread, TX/credits from RPC thread) and read without a mutex — aligned 32-bit reads are atomic on Cortex-M.

New API:
- `ble_svc_serial_get_stats` / `_reset_stats`
- `ble_profile_serial_get_stats` / `_reset_stats`

New CLI:
- `bt serial_stats` — prints snapshot plus a derived `TX in flight` (submitted − acked). Sustained growth, non-zero `tx_errors`, or heavy `tx_retries` indicate a wedged stack or a peer that stopped ACKing. `rx_overruns` indicates the peer is ignoring the FFF4 credit characteristic.
- `bt serial_stats reset` — zeros the counters.

## Test plan

- [ ] Flash firmware, pair Flipper Android app
- [ ] Enter Remote Control and drive input continuously for ≥ 3 min — verify no hang and no BLE restart request
- [ ] `bt serial_stats` over serial CLI during test — verify `tx_submitted` and `tx_acked` track together, `tx_errors` stays 0, `tx_retries` stays low
- [ ] Exercise other RPC-over-BLE features (file browser, screenshot, storage) — verify no regressions
- [ ] Test dual-connection scenario (peripheral + central): confirm peripheral TX still goes only to the phone, unchanged from d60c961

## Files changed

- `targets/f7/ble_glue/services/serial_service.{c,h}` — revert, retry loop, stats
- `targets/f7/ble_glue/profiles/serial_profile.{c,h}` — stats pass-through
- `applications/services/bt/bt_service/bt.c` — honor TX return + bounded ACK wait
- `applications/services/bt/bt_cli.c` — `serial_stats` subcommand
- `targets/f7/api_symbols.csv` — register new public symbols

https://claude.ai/code/session_014DEHtEKnqocbLTJ5ycCftS