### PR TITLE
moon_companion: skip PairRequest when already bonded

### DIFF
--- a/applications/services/moon_companion/moon_companion.c
+++ b/applications/services/moon_companion/moon_companion.c
@@ -747,11 +747,20 @@ int32_t moon_companion_srv(void* p) {
             return 0;
 
         case MoonMsgBeginPairing:
-            FURI_LOG_I(TAG, "Begin pairing (PIN %s)", moon->pairing_pin);
+            FURI_LOG_I(TAG, "Begin pairing (PIN %s) paired=%d",
+                       moon->pairing_pin, moon->persist.paired);
             moon->pairing_active = true;
-            /* Drop any existing pairing — user asked for a fresh one. */
-            memset(&moon->persist, 0, sizeof(moon->persist));
-            moon_companion_save(moon);
+            /* Only wipe persist for a fresh pair. If we already have a
+             * bond + auth_token (from /int/.moon_companion.settings and
+             * the BT stack's .bt.keys), keep them — the user probably
+             * tapped "Re-pair Phone" just to trigger a reconnect.
+             * on_ble_state_changed will route us through the authed path
+             * instead of sending a new PairRequest. Explicit wipes only
+             * happen via MoonMsgForget. */
+            if(!moon->persist.paired) {
+                memset(&moon->persist, 0, sizeof(moon->persist));
+                moon_companion_save(moon);
+            }
             moon_ble_start_scan(moon->ble);
             break;
 
@@ -839,9 +848,20 @@ int32_t moon_companion_srv(void* p) {
                            "BLE Connected: pairing_active=%d paired=%d",
                            moon->pairing_active,
                            moon->persist.paired);
-                if(moon->pairing_active) {
+                /* Pairing intent + existing bond = the user hit "Re-pair"
+                 * on a phone we already know. Skip PairRequest entirely and
+                 * take the authed path so reconnects stay silent. Clear
+                 * pairing_active so the pair scene's is_paired() poll lets
+                 * it close normally. */
+                if(moon->pairing_active && !moon->persist.paired) {
                     moon_companion_on_pair_connected(moon);
                 } else if(moon->persist.paired) {
+                    if(moon->pairing_active) {
+                        FURI_LOG_I(TAG,
+                                   "Re-pair with bonded phone — skipping "
+                                   "PairRequest, using stored token");
+                        moon->pairing_active = false;
+                    }
                     moon_companion_on_authed_connected(moon);
                 }
             } else if(

--- a/applications/settings/moon_companion_settings/scenes/moon_companion_settings_scene_pair.c
+++ b/applications/settings/moon_companion_settings/scenes/moon_companion_settings_scene_pair.c
@@ -9,27 +9,33 @@ static void update_popup(MoonCompSettingsApp* app, MoonConnectionState state) {
     /* Just-Works pairing: no PIN is exchanged. Keep the header stable
      * instead of flashing a decorative 6-digit placeholder the user can't
      * do anything with. */
-    (void)app;
-    const char* header = "Pairing";
+    const bool reconnect = moon_companion_is_paired(app->moon);
+    const char* header = reconnect ? "Reconnecting" : "Pairing";
     char body[96];
 
     switch(state) {
     case MoonConnStateConnected:
         snprintf(body, sizeof(body),
-            moon_companion_is_paired(app->moon) ? "Paired!\nPress back to return." :
+            reconnect ? "Connected\nPress back to return." :
             "Connected\nWaiting for phone...");
         break;
     case MoonConnStateConnecting:
-        snprintf(body, sizeof(body), "Connecting...\nApprove pair on phone.");
+        snprintf(body, sizeof(body),
+            reconnect ? "Connecting...\nUsing stored pairing." :
+            "Connecting...\nApprove pair on phone.");
         break;
     case MoonConnStateScanning:
-        snprintf(body, sizeof(body), "Scanning for phone\nwith pair mode on.");
+        snprintf(body, sizeof(body),
+            reconnect ? "Searching for\nyour paired phone." :
+            "Scanning for phone\nwith pair mode on.");
         break;
     case MoonConnStateYielded:
         snprintf(body, sizeof(body), "Radio yielded\nto another app.");
         break;
     default:
-        snprintf(body, sizeof(body), "Start pair mode\non the phone.");
+        snprintf(body, sizeof(body),
+            reconnect ? "Waiting to reconnect..." :
+            "Start pair mode\non the phone.");
         break;
     }
     popup_set_header(app->popup, header, 64, 10, AlignCenter, AlignTop);


### PR DESCRIPTION
## Summary

Pressing "Re-pair Phone" used to wipe `/int/.moon_companion.settings` and send a fresh `PairRequest` even when the existing bond + token were still valid. End result: a 5-second "Pairing…" popup for what should've been a silent reconnect. (Android's logs even showed the same token coming back as `reused` — Android was already doing the right thing; the Flipper was throwing away its own state and asking again.)

- `MoonMsgBeginPairing` (`moon_companion.c`) only wipes `persist` when we aren't already paired. `MoonMsgForget` stays as the only explicit wipe path.
- `on_ble_state_changed → Connected`: if `pairing_active && persist.paired`, skip `on_pair_connected` and go straight to `on_authed_connected`. Clears `pairing_active` so the pair scene's `is_paired()` poll closes cleanly.
- `moon_companion_settings_scene_pair.c` relabels the popup header to "Reconnecting…" and updates body copy when entered in the paired state.

No protocol or persist-format changes — `/int/.moon_companion.settings` stays byte-identical. Pairs with the Android-side `EncryptedBondedTokenStore` change (Moon-Companion v0.5.0-alpha), so the app-level token persists on both sides now.

## Test plan

- [ ] CI size-check passes
- [ ] With a fresh flash + unpaired phone: "Pair Phone" runs full pair flow, OS prompt appears once, stored on both sides
- [ ] With a paired phone: "Re-pair Phone" shows "Reconnecting…" header and skips the PairRequest — confirm via logs (no `on_pair_connected: sending PairRequest`), phone-side logcat shows no `Paired!` line
- [ ] "Forget Phone" still wipes and next pair re-issues a fresh token
- [ ] Auto-reconnect after link drop still works silently (unchanged path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)